### PR TITLE
fix: gcloud rsyncで使えないオプションを削除

### DIFF
--- a/run_scraper.sh
+++ b/run_scraper.sh
@@ -6,7 +6,7 @@ if [ ! -d logs ]; then
 mkdir logs
 fi
 
-gcloud storage cp gs://${BUCKET_NAME}/logs/${DATE}* ./logs --recursive -x '.*\.DS_Store'
+gcloud storage cp gs://${BUCKET_NAME}/logs/${DATE}* ./logs --recursive
 
 poetry run python main.py -L logs -O parquet
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能の変更**
	- Google Cloud Storageバケットからローカルの`logs`ディレクトリへのファイルコピー処理を簡素化し、`.*\.DS_Store`パターンのファイルを除外せずに全てのファイルを再帰的にコピーするように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->